### PR TITLE
Fix claim rewards

### DIFF
--- a/src/hooks/useClaimRewards.ts
+++ b/src/hooks/useClaimRewards.ts
@@ -9,7 +9,7 @@ export const useClaimRewards = () => {
   const { connection } = useConnection();
   const [pending, setPending] = useState(false);
   const { publicKey, sendTransaction } = useWallet();
-  const { exists } = useRewardMint();
+  const { isInitialized } = useRewardMint();
 
   const claim = useCallback(async () => {
     if (!publicKey || pending) return;
@@ -19,7 +19,7 @@ export const useClaimRewards = () => {
     try {
       const transaction = new Transaction();
 
-      if (!exists) {
+      if (!isInitialized) {
         transaction.add(getInitializeRewardsInstruction(publicKey));
       }
 

--- a/src/hooks/useTokenMint.ts
+++ b/src/hooks/useTokenMint.ts
@@ -9,7 +9,7 @@ import { findRewardTokenMint } from "@/utils/locker";
 export const useTokenMint = () => {
   const { publicKey } = useWallet();
   const [pending, setPending] = useState(false);
-  const balance = useRecoilValue(
+  const { amount: balance, isInitialized } = useRecoilValue(
     mintAccountAtom({ mint: MINT, owner: publicKey })
   );
 
@@ -30,7 +30,7 @@ export const useTokenMint = () => {
   }, [balance, pending]);
 
   return {
-    exists: balance !== null,
+    isInitialized,
     balance,
     pending,
     requestTokens,
@@ -41,7 +41,7 @@ export const useRewardMint = () => {
   const mint = findRewardTokenMint();
   const { publicKey } = useWallet();
   const [pending, setPending] = useState(false);
-  const balance = useRecoilValue(
+  const { amount: balance, isInitialized } = useRecoilValue(
     mintAccountAtom({ mint, owner: publicKey, decimals: 4 })
   );
 
@@ -62,7 +62,7 @@ export const useRewardMint = () => {
   }, [balance, pending]);
 
   return {
-    exists: balance !== null,
+    isInitialized,
     balance,
     pending,
     requestTokens,

--- a/src/state/account/selectors.ts
+++ b/src/state/account/selectors.ts
@@ -22,14 +22,15 @@ export const overviewItemsAtom = selectorFamily<
     ({ get }) => {
       if (!publicKey) return [];
 
-      const rewardMint = findRewardTokenMint();
       const member = get(memberAccountAtom(publicKey));
-      const tokenBalance =
-        get(mintAccountAtom({ mint: MINT, owner: publicKey })) || 0;
-      const rewardBalance =
-        get(
-          mintAccountAtom({ mint: rewardMint, owner: publicKey, decimals: 4 })
-        ) || 0;
+      const tokenMint = get(mintAccountAtom({ mint: MINT, owner: publicKey }));
+      const rewardMint = get(
+        mintAccountAtom({
+          mint: findRewardTokenMint(),
+          owner: publicKey,
+          decimals: 4,
+        })
+      );
 
       if (!member) return [];
 
@@ -37,13 +38,13 @@ export const overviewItemsAtom = selectorFamily<
         {
           key: "total",
           media: { src: "./images/lfv.png" },
-          value: member.totalAmount + tokenBalance,
+          value: member.totalAmount + tokenMint.amount,
           label: "Total Virgin",
         },
         {
           key: "reward",
           media: { src: "./svg/coin.svg" },
-          value: rewardBalance,
+          value: rewardMint.amount,
           label: "Entries",
         },
         {

--- a/src/state/mints/atoms.ts
+++ b/src/state/mints/atoms.ts
@@ -1,15 +1,23 @@
 import { atomFamily } from "recoil";
 import { effectMintAccountAtom } from "./effects";
-import { PublicKey } from "@solana/web3.js";
 import { DECIMALS } from "@/utils/locker/constants";
+import { type TokenMint } from "./types";
+import { PublicKey } from "@solana/web3.js";
 
-export const mintAccountAtom = atomFamily<
-  number | undefined,
-  { mint: PublicKey; owner: PublicKey | null; decimals?: number }
->({
+type MintAccountParams = {
+  mint: PublicKey;
+  owner: PublicKey | null;
+  decimals?: number;
+};
+
+export const mintAccountAtom = atomFamily<TokenMint, MintAccountParams>({
   key: "mint-holding-atom",
   effects: ({ mint, owner, decimals = DECIMALS }) => [
     effectMintAccountAtom(mint, owner, decimals),
   ],
-  default: undefined,
+  default: ({ mint }) => ({
+    mint,
+    amount: 0,
+    isInitialized: false,
+  }),
 });

--- a/src/state/mints/types.ts
+++ b/src/state/mints/types.ts
@@ -1,0 +1,7 @@
+import { PublicKey } from "@solana/web3.js";
+
+export type TokenMint = {
+  mint: PublicKey | null;
+  amount: number;
+  isInitialized: boolean;
+};


### PR DESCRIPTION
- Rewards token account was not being initialised when one did not exist, meaning new users could not claim rewards.